### PR TITLE
Add total profit by block table in db

### DIFF
--- a/alembic/versions/a5a44a7c854d_create_total_profit_by_block_table.py
+++ b/alembic/versions/a5a44a7c854d_create_total_profit_by_block_table.py
@@ -1,0 +1,32 @@
+"""create total profit by block table
+
+Revision ID: a5a44a7c854d
+Revises: 5c5375de15fd
+Create Date: 2022-12-12 02:46:57.125040
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a5a44a7c854d'
+down_revision = '5c5375de15fd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "total_profit_by_block",
+        sa.Column("block_number", sa.Numeric, primary_key=True),
+        sa.Column("transaction_hash", sa.String(66), nullable=False),
+        sa.Column("token_debt", sa.String(66), nullable=True),
+        sa.Column("amount_debt", sa.Numeric, nullable=False),
+        sa.Column("token_received", sa.String(66), nullable=False),
+        sa.Column("amount_received", sa.Numeric, nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("total_profit_by_block")

--- a/alembic/versions/a5a44a7c854d_create_total_profit_by_block_table.py
+++ b/alembic/versions/a5a44a7c854d_create_total_profit_by_block_table.py
@@ -5,13 +5,12 @@ Revises: 5c5375de15fd
 Create Date: 2022-12-12 02:46:57.125040
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = 'a5a44a7c854d'
-down_revision = '5c5375de15fd'
+revision = "a5a44a7c854d"
+down_revision = "5c5375de15fd"
 branch_labels = None
 depends_on = None
 

--- a/mev_inspect/crud/total_profits.py
+++ b/mev_inspect/crud/total_profits.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from mev_inspect.db import write_as_csv
+from mev_inspect.schemas.total_profits import TotalProfits
+
+
+def write_total_profits_for_blocks(
+    inspect_db_session,
+    total_profits_for_blocks: List[TotalProfits],
+) -> None:
+    items_generator = (
+        (
+            total_profits_for_unique_block.block_number,
+            total_profits_for_unique_block.transaction_hash,
+            total_profits_for_unique_block.token_debt,
+            total_profits_for_unique_block.amount_debt,
+            total_profits_for_unique_block.token_received,
+            total_profits_for_unique_block.amount_received,
+        )
+        for total_profits_for_unique_block in total_profits_for_blocks
+    )
+    write_as_csv(inspect_db_session, "total_profit_by_block", items_generator)

--- a/mev_inspect/schemas/total_profits.py
+++ b/mev_inspect/schemas/total_profits.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class TotalProfits(BaseModel):
+    block_number: int
+    transaction_hash: str
+    token_debt: str
+    amount_debt: int
+    token_received: str
+    amount_received: int


### PR DESCRIPTION
## What does this PR do?

This PR adds a new migration to the database which creates a `Total Profits Per Block` entity.
It comes with a method to store instances of it in bulk, below is a snippet of the usage for this method:
```python
test_total_profits: List[TotalProfits] = [
            TotalProfits(
                block_number=1,
                transaction_hash="0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5",
                token_debt="0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5",
                amount_debt=0,
                token_received="0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5",
                amount_received=1,
            ),
            TotalProfits(
                block_number=2,
                transaction_hash="0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263",
                token_debt="0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263",
                amount_debt=0,
                token_received="0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263",
                amount_received=1,
            )
]

write_total_profits_for_blocks(
  db_session=inspect_db_session,
  total_profits_for_blocks=test_total_profits
)
```

## Related issue

This PR is part of #3.

## Testing

I've tried the method and the data is correctly stored in the DB.

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
