### PR TITLE
feat: add retries for jsonrpc requests

### DIFF
--- a/profit_analysis/block_utils.py
+++ b/profit_analysis/block_utils.py
@@ -1,4 +1,5 @@
 import datetime
+from time import sleep
 
 import pandas as pd
 from profit_analysis.column_names import BLOCK_KEY, TIMESTAMP_KEY
@@ -15,7 +16,13 @@ def add_block_timestamp(w3, profit_by_block):
 
 
 def get_block_timestamp(w3, block):
-    block_info = w3.eth.get_block(int(block))
-    ts = block_info[TIMESTAMP_KEY]
-    dt = datetime.datetime.fromtimestamp(ts)
-    return dt
+    while True:
+        try:
+            block_info = w3.eth.get_block(int(block))
+            ts = block_info[TIMESTAMP_KEY]
+            dt = datetime.datetime.fromtimestamp(ts)
+
+            return dt
+        except Exception as e:
+            print(f"Error, retrying {e}")
+            sleep(0.05)


### PR DESCRIPTION
## What does this PR do?

This PR adds the retry feature when failing to get values using the JSON-RPC node (get logs or get blocks).

## Related issue

Due to the high volume of requests we make to the archive node, requests might fail and stop the analysis process.
This feature prevents this from happening.

## Testing

I ran the analysis for 1000 blocks and it works and retries failing requests correctly.

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
