### PR TITLE
fix: reconnect to local node when rotating rpc endpoints

### DIFF
--- a/mev_inspect/web3_provider.py
+++ b/mev_inspect/web3_provider.py
@@ -60,6 +60,12 @@ class Web3Provider:
             self.w3_provider_archival = create_web3_archival(
                 self.rpc_endpoint_base_url + self.current_rpc
             )
+        else:
+            # if we use a local node, just try to reconnect
+            rpc_url = os.environ.get("RPC_URL")
+            self.w3_provider = create_web3(rpc_url)
+            self.w3_provider_async = create_web3_async(rpc_url)
+            self.w3_provider_archival = create_web3_archival(rpc_url)
 
 
 def split_rpc_url(rpc_url):


### PR DESCRIPTION
## What does this PR do?

When the connexion unexpectedly ends, the `rotate_rpc_url` function is called and in the case of a local node it will try to reconnect.

## Related issue

resolves #72 


## Testing

- [x] Run 28M of blocks

## Checklist before merging
- [x] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [x] Installed and ran pre-commit hooks
- [x] All tests pass with `./mev test`
